### PR TITLE
added tags, summary or content to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ You could add `params` into your site's `config.toml` file:
   GithubID = "Your Github ID"
   TwitterID = "Your Twitter ID"
   AnalyticsID = "Your Google Analytics tracking code"
+  Summary = true  # takes true or false
+  Content = false  # takes true or false
+  # if both are set to true, summary is shown.
 ```
 
 if you use `config.yaml`, it could look like:
@@ -35,6 +38,9 @@ params:
   GithubID: "Your Github ID"
   TwitterID: "Your Twitter ID"
   AnalyticsID: "Your Google Analytics tracking code"
+  Summary: true # takes true or false
+  Content: false # takes true or false
+  # if both are set to true, summary is shown
 ```
 
 ## Build your site

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -38,7 +38,7 @@
     </div>
     {{ partial "footer.html" . }}
   </div>
-  <script src="{{ .Site.BaseUrl }}js/slim.js"></script>
+  <script src="{{ .Site.BaseURL }}js/slim.js"></script>
   {{ with .Site.Params.AnalyticsID }}{{ partial "analytics.html" . }}{{ end }}
 
 </body>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+
+<head>
+  {{ partial "head.html" . }}
+</head>
+
+<body>
+  <div class="container">
+    {{ partial "header.html" . }}
+    <div class="content">
+      <div class="posts">
+        {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }} {{ range $paginator.Pages }}
+        <div class="post">
+          <h2 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+          <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}</span>
+		  {{ if .Params.tags }}
+			<span class="post-tags">
+		  	{{ range .Params.tags }}
+			          #<a href="/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+		  	{{ end }}
+		    </span>
+		  {{ end }}
+		  {{ if .Site.Params.Summary }}
+		  	<div class="summary">
+				{{ .Summary }}
+				<a class="read-more" href="{{.RelPermalink}}">&hellip;</a>
+			</div>
+		  {{ else if .Site.Params.Content }}
+			<div class="content">
+				{{ .Content }}
+			</div>
+		   {{ end }}
+        </div>
+        {{ end }}
+      </div>
+      {{ partial "pagination.html" . }}
+    </div>
+    {{ partial "footer.html" . }}
+  </div>
+  <script src="{{ .Site.BaseUrl }}js/slim.js"></script>
+  {{ with .Site.Params.AnalyticsID }}{{ partial "analytics.html" . }}{{ end }}
+
+</body>
+
+</html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,7 +18,7 @@
     </div>
     {{ partial "footer.html" . }}
   </div>
-  <script src="{{ .Site.BaseUrl }}/js/slim.js"></script>
+  <script src="{{ .Site.BaseURL }}/js/slim.js"></script>
   {{ with .Site.Params.AnalyticsID }}{{ partial "analytics.html" . }}{{ end }}
 
 </body>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,7 +38,7 @@
     </div>
     {{ partial "footer.html" . }}
   </div>
-  <script src="{{ .Site.BaseUrl }}js/slim.js"></script>
+  <script src="{{ .Site.BaseURL }}/js/slim.js"></script>
   {{ with .Site.Params.AnalyticsID }}{{ partial "analytics.html" . }}{{ end }}
 
 </body>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,6 +14,23 @@
         <div class="post">
           <h2 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
           <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}</span>
+		  {{ if .Params.tags }}
+			<span class="post-tags">
+		  	{{ range .Params.tags }}
+			          #<a href="/tags/{{ . | urlize }}">{{ . }}</a>&nbsp;
+		  	{{ end }}
+		    </span>
+		  {{ end }}
+		  {{ if .Site.Params.Summary }}
+		  	<div class="summary">
+				{{ .Summary }}
+				<a class="read-more" href="{{.RelPermalink}}">&hellip;</a>
+			</div>
+		  {{ else if .Site.Params.Content }}
+			<div class="content">
+				{{ .Content }}
+			</div>
+		   {{ end }}
         </div>
         {{ end }}
       </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,8 +3,8 @@
 <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
 
 <!-- CSS -->
-<link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/slim.css">
-<link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/highlight.min.css">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/slim.css">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/highlight.min.css">
 <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,600&subset=latin,latin-ext' rel='stylesheet'>
 <!-- Icons -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,8 +5,7 @@
 <!-- CSS -->
 <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/slim.css">
 <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/highlight.min.css">
-<link href='http://fonts.useso.com/css?family=Open+Sans:400,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
-
+<link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,600&subset=latin,latin-ext' rel='stylesheet'>
 <!-- Icons -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">
 <link rel="shortcut icon" href="/favicon.ico">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <div class="header">
-  <h1 class="site-title"><a href="{{ .Site.BaseUrl }}">{{ .Site.Title }}</a></h1>
+  <h1 class="site-title"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
   <p class="site-tagline">{{ .Site.Params.Subtitle }}</p>
   <div class="nav">
     <a class="nav-btn" href="#">
@@ -7,7 +7,7 @@
     </a>
     <ul class="nav-list">
       {{ range .Site.Menus.main }}
-      <li><a href="{{ .Url }}">{{ .Name }}</a></li>
+      <li><a href="{{ .URL }}">{{ .Name }}</a></li>
       {{end}} 
 	  <li class="spacer">&ac;</li>
 {{ with .Site.Params.GithubID }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,9 @@
     <ul class="nav-list">
       {{ range .Site.Menus.main }}
       <li><a href="{{ .Url }}">{{ .Name }}</a></li>
-      {{end}} {{ with .Site.Params.GithubID }}
+      {{end}} 
+	  <li class="spacer">&ac;</li>
+{{ with .Site.Params.GithubID }}
       <li><a href="https://github.com/{{.}}">Github</a></li>{{ end }} {{ with .Site.Params.TwitterID }}
       <li><a href="https://twitter.com/{{.}}">Twitter</a></li>{{ end }} {{ with .Site.Params.LinkedInID }}
       <li><a href="http://linkedin.com/in/{{.}}">LinkedIn</a></li>{{ end }}

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,5 +1,5 @@
 <div class="pagination">
   {{ if .Paginator.HasPrev }}
-  <a class="btn previous" href="{{ .Paginator.Prev.Url }}">Newer</a> {{ end }} {{ if .Paginator.HasNext }}
-  <a class="btn next" href="{{ .Paginator.Next.Url }}">Older</a> {{ end }}
+  <a class="btn previous" href="{{ .Paginator.Prev.URL }}">Newer</a> {{ end }} {{ if .Paginator.HasNext }}
+  <a class="btn next" href="{{ .Paginator.Next.URL }}">Older</a> {{ end }}
 </div>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -25,8 +25,8 @@
     </div>
     {{ partial "footer.html" . }}
   </div>
-  <script src="{{ .Site.BaseUrl }}/js/slim.js"></script>
-  <script src="{{ .Site.BaseUrl }}/js/highlight.min.js"></script>
+  <script src="{{ .Site.BaseURL }}/js/slim.js"></script>
+  <script src="{{ .Site.BaseURL }}/js/highlight.min.js"></script>
   <script>
     hljs.initHighlightingOnLoad();
   </script>

--- a/static/css/slim.css
+++ b/static/css/slim.css
@@ -212,6 +212,10 @@ button,
   -webkit-transition: all 0.2s;
           transition: all 0.2s; }
 
+.nav-list .spacer {
+	text-align: center;
+}
+
 .ci {
   display: inline-block;
   font-size: inherit;
@@ -338,3 +342,19 @@ button,
 
 .post-content {
   margin: 2rem 0; }
+
+/* styling for tags on homepage */
+
+.post-tags {
+  color: #ccc;
+  font-size: 14px;
+  position: absolute;
+  right: 25px;
+  top: 45px; 
+  text-align: right;
+}
+
+.post-tags a {
+	color: #ccc;
+}
+

--- a/static/css/slim.css
+++ b/static/css/slim.css
@@ -14,7 +14,7 @@ a {
 
 img {
   max-width: 100%;
-  margin: 0 0 1rem;
+  margin: 1rem 0 0 1rem;
   border: 0;
   border-radius: 5px; }
 

--- a/static/css/slim.css
+++ b/static/css/slim.css
@@ -337,8 +337,9 @@ button,
 .post-date {
   color: #ccc;
   font-size: 14px;
-  position: absolute;
-  top: 45px; }
+  margin-top: -25px;
+  display:block;
+  position: relative; }
 
 .post-content {
   margin: 2rem 0; }
@@ -347,11 +348,13 @@ button,
 
 .post-tags {
   color: #ccc;
+  display: block;
   font-size: 14px;
-  position: absolute;
-  right: 25px;
-  top: 45px; 
+  position: relative;
+  margin-top: -25px;
+  margin-left: 125px;
   text-align: right;
+  max-width: 525px;
 }
 
 .post-tags a {

--- a/static/css/slim.css
+++ b/static/css/slim.css
@@ -40,8 +40,8 @@ tbody tr:nth-child(odd) th {
   background-color: #f9f9f9; }
 
 body {
-  color: #333;
-  font-family: Merriweather, 'Hiragino Sans GB', 'Microsoft YaHei', 'WenQuanYi Micro Hei', Serif;
+  color: #555;
+  font-family: Verdana, 'Merriweather', 'Hiragino Sans GB', 'Microsoft YaHei', 'WenQuanYi Micro Hei', Serif;
   font-size: 100%;
   line-height: 1.85;
   letter-spacing: 0.01rem; }


### PR DESCRIPTION
- Added tags to homepage list view
- Added Summary or content switch to homepage view
- Added small separator for menu between pages and external links
- Changed from useso.com to google api as according to useso.com
  instructions on their homepage as source for fonts — also loads a lot
  faster
- added taxonomy page, by copying the list template under _default
- updated some css, to attribute for the changes and made it a bit more dynamic
- updated README to represent changes and added functionality
