### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,4 +11,4 @@
 <link rel="shortcut icon" href="/favicon.ico">
 
 <!-- RSS -->
-<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.