### PR TITLE
Custom FooterMSG not working

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <div class="footer">
-  {{ if isset .Site.Params "FooterMsg" }}
+  {{ if .Site.Params.FooterMsg }}
   <p>{{ .Site.Params.FooterMsg | safeHTML }}</p>
   {{else}}
   <p>Powered by <a href="http://gohugo.io">Hugo</a>. This theme—Slim—is open sourced on <a href="https://github.com/zhe/hugo-theme-slim">Github</a>.</p>


### PR DESCRIPTION
Changed way that the FooterMsg is being checked for existence.

With my hugo installation 
```
hugo version
Hugo Static Site Generator v0.24.1 darwin/amd64 BuildDate: 2017-07-03T16:06:45+02:00
```
the `FooterMsg` parameter was ignored. After removing the `isset` and doing a ` if .Site.Params.FooterMsg` both rendering the default as well as setting a custom `FooterMsg` is working.